### PR TITLE
Added a check for an empty result

### DIFF
--- a/cross-domain-ajax/jquery.xdomainajax.js
+++ b/cross-domain-ajax/jquery.xdomainajax.js
@@ -53,7 +53,7 @@ jQuery.ajax = (function(_ajax){
             o.success = (function(_success){
                 return function(data) {
                     
-                    if (_success) {
+                    if (_success && data.results.length > 0) {
                         // Fake XHR callback.
                         _success.call(this, {
                             responseText: data.results[0]


### PR DESCRIPTION
In my case, this was caused when YQL returned an error because the site had robots.txt file that excluded Yahoo.
