### PR TITLE
Support for retrieving XML pages

### DIFF
--- a/cross-domain-ajax/jquery.xdomainajax.js
+++ b/cross-domain-ajax/jquery.xdomainajax.js
@@ -28,8 +28,15 @@ jQuery.ajax = (function(_ajax){
         
         if ( /get/i.test(o.type) && !/json/i.test(o.dataType) && isExternal(url) ) {
             
-            // Manipulate options so that JSONP-x request is made to YQL
-            
+	    	//Check if request is a XML file
+	    	if(/xml/i.test(o.dataType))
+	    	{
+	    		//Replace table html for xml in query and remove xpath in the 'where' conditions
+				query = query.replace('html','xml');
+				query = query.replace(' and xpath="*"','');
+			};
+
+            // Manipulate options so that JSONP-x request is made to YQL            
             o.url = YQL;
             o.dataType = 'json';
             


### PR DESCRIPTION
changes yql query according to jQuery.ajax() dataType parameter. If
parameter is set to xml, it is possible to retrieve cross domain xml
files like rss feeds.

sample: 

$.ajax({
        url: 'http://rss.news.yahoo.com/rss/topstories',
    type: 'GET',
    dataType: 'xml',
    success: function(res) {
            var xmldoc = $.parseXML(res.responseText);
        //Do other stuff here
    }
});
