### PR TITLE
undefined request type in $.ajax

### DIFF
--- a/cross-domain-ajax/jquery.xdomainajax.js
+++ b/cross-domain-ajax/jquery.xdomainajax.js
@@ -26,7 +26,7 @@ jQuery.ajax = (function(_ajax){
         
         var url = o.url;
         
-        if ( /get/i.test(o.type) && !/json/i.test(o.dataType) && isExternal(url) ) {
+        if ( (typeof o.type === 'undefined' || /get/i.test(o.type)) && !/json/i.test(o.dataType) && isExternal(url) ) {
             
             // Manipulate options so that JSONP-x request is made to YQL
             

--- a/cross-domain-ajax/test/test.js
+++ b/cross-domain-ajax/test/test.js
@@ -1,9 +1,6 @@
 
 
-test('GET', function(){
-    
-    expect(1);
-    stop();
+asyncTest('GET', 1, function(){
     
     jQuery.get('http://google.com', function(res){
         ok(
@@ -13,4 +10,18 @@ test('GET', function(){
         start();
     });
     
+});
+
+asyncTest('Implicit GET', 1, function(){
+
+    jQuery.ajax({
+        url: 'http://yahoo.com',
+        success: function(res){
+            start();
+            ok(
+                !!(res && res.responseText),
+                'Implicit GET Request to Google.com succeeded!'
+            );
+        }
+    });
 });


### PR DESCRIPTION
Fixes $.ajax when GET is not explicitly specified.

e.g.
$.ajax({
  url: "http://google.com",
  complete: function(resp) { console.log(resp.responseText.length); }
});
