### PR TITLE
Exception handled when no results are returned

### DIFF
--- a/cross-domain-ajax/jquery.xdomainajax.js
+++ b/cross-domain-ajax/jquery.xdomainajax.js
@@ -56,7 +56,7 @@ jQuery.ajax = (function(_ajax){
                     if (_success) {
                         // Fake XHR callback.
                         _success.call(this, {
-                            responseText: data.results[0]
+                            responseText: (data.results[0] || '')
                                 // YQL screws with <script>s
                                 // Get rid of them
                                 .replace(/<script[^>]+?\/>|<script(.|\s)*?\/script>/gi, '')


### PR DESCRIPTION
If you call a JSON API and get no results back, the plugin throws an error. This patch fixes it.
